### PR TITLE
Updates for site_location and Routing - 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Terraform module which deploys into an new or existing VPC and Internet Gateway,
 For the vpc_id and internet_gateway_id, leave null to create new or add an id of the already created resources to use existing.
 
 ## NOTE
-- For help with finding exact sytax to match site location for city, state_name, country_name and timezone, please refer to the [cato_siteLocation data source](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/data-sources/siteLocation).
+- Site Location for Cato Socket is automatically inferred based on the region being deployed, however this can be overridden if necessary. 
+- For help with finding exact syntax to match site location for city, state_name, country_name and timezone, please refer to the [cato_siteLocation data source](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/data-sources/siteLocation).
 - For help with finding a license id to assign, please refer to the [cato_licensingInfo data source](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/data-sources/licensingInfo).
 
 <details>
@@ -63,13 +64,13 @@ module "vsocket-aws-ha-vpc" {
   source                      = "catonetworks/vsocket-aws-ha-vpc/cato"
   token                       = var.token
   account_id                  = var.account_id
+  region                      = var.region
   key_pair                    = "Your-AWS-KeyPair-Name-Here"
   site_name                   = "Your-Cato-site-name-here"
   site_description            = "Your Cato site Description here"
   site_type                   = "CLOUD_DC"
   vpc_id                      = null
   internet_gateway_id         = null
-  native_network_range        = "10.132.0.0/18"
   vpc_range                   = "10.132.0.0/18"
   subnet_range_mgmt_primary   = "10.132.1.0/24"
   subnet_range_mgmt_secondary = "10.132.2.0/24"
@@ -83,26 +84,30 @@ module "vsocket-aws-ha-vpc" {
   wan_eni_secondary_ip        = "10.132.4.6"
   lan_eni_primary_ip          = "10.132.5.5"
   lan_eni_secondary_ip        = "10.132.6.5"
-  ingress_cidr_blocks         = ["0.0.0.0/0"]
   lan_ingress_cidr_blocks     = ["0.0.0.0/0"]
-  site_location = {
-    city         = "London"
-    country_code = "GB"
-    state_code   = null
-    timezone     = "Europe/London"
-  }
+  #Site Location Derived from Region
+  
+  #Example Networks to be routed through to AWS
+  routed_networks = {
+    "Peered-VPC-1" = "10.100.1.0/24"
+    "App-VPC" = "10.100.3.0/24"
+    "DatabaseVPC" = "10.100.2.0/24"
+    }
+
+  #Example Tags
   tags = {
     Test  = "Test tag"
     Test2 = "Test2 tag"
   }
 }
 
+# Example Outputs 
 output "vsocket-ha-output" {
   value = module.vsocket-aws-ha-vpc
 }
 ```
 
-## Imporant note for troubleshooting
+## Important note for troubleshooting
 
 In the event the module fails with the following error, this is an indication that the primary socket instance took longer than 5 minutes to upgrade and initialize.  
 
@@ -113,17 +118,18 @@ outputs.tf line X, in output "secondary_socket_site_serial":
 │     │ data.cato_accountSnapshotSite.aws-site-secondary.info.sockets is list of object with 1 element
 ```
 
-We need to rerun the process to add the secondary socket. To resolve this, simply taint the `null_resource.configure_secondary_aws_vsocket` resource and re-run terraform apply.  
+We need to rerun the process to add the secondary socket. To resolve this, simply taint the `terraform_data.configure_secondary_aws_vsocket` resource and re-run terraform apply.  
+
 Example:
 
 ```
 terraform state list
-terraform taint null_resource.configure_secondary_aws_vsocket
+terraform taint terraform_data.configure_secondary_aws_vsocket
 terraform apply
 ```
 
 ## Site Location Reference
-
+Site Location is automatically inferred based on Region, if you'd like to override this, here is information on how to look up values. 
 For more information on site_location syntax, use the [Cato CLI](https://github.com/catonetworks/cato-cli) to lookup values.
 
 ```bash
@@ -148,15 +154,18 @@ Apache 2 Licensed. See [LICENSE](https://github.com/catonetworks/terraform-cato-
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.98.0 |
+| <a name="requirement_cato"></a> [cato](#requirement\_cato) | >= 0.0.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_cato"></a> [cato](#provider\_cato) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.98.0 |
+| <a name="provider_cato"></a> [cato](#provider\_cato) | >= 0.0.27 |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -207,17 +216,18 @@ No modules.
 | [aws_subnet.wan_subnet_secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.cato-vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [cato_license.license](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/resources/license) | resource |
+| [cato_network_range.routedNetworks](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/resources/network_range) | resource |
 | [cato_socket_site.aws-site](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/resources/socket_site) | resource |
-| [null_resource.configure_secondary_aws_vsocket](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.sleep_300_seconds](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.sleep_300_seconds-HA](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.sleep_30_seconds](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [terraform_data.configure_secondary_aws_vsocket](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_ami.vsocket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [aws_availability_zones.available_zones](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [cato_accountSnapshotSite.aws-site-2](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/data-sources/accountSnapshotSite) | data source |
 | [cato_accountSnapshotSite.aws-site-primary](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/data-sources/accountSnapshotSite) | data source |
 | [cato_accountSnapshotSite.aws-site-secondary](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/data-sources/accountSnapshotSite) | data source |
+| [cato_siteLocation.site_location](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/data-sources/siteLocation) | data source |
 
 ## Inputs
 
@@ -227,8 +237,7 @@ No modules.
 | <a name="input_baseurl"></a> [baseurl](#input\_baseurl) | Cato Networks API URL | `string` | `"https://api.catonetworks.com/api/v1/graphql2"` | no |
 | <a name="input_connection_type"></a> [connection\_type](#input\_connection\_type) | Model of Cato vsocket | `string` | `"SOCKET_AWS1500"` | no |
 | <a name="input_ebs_disk_size"></a> [ebs\_disk\_size](#input\_ebs\_disk\_size) | Size of disk | `number` | `32` | no |
-| <a name="input_ebs_disk_type"></a> [ebs\_disk\_type](#input\_ebs\_disk\_type) | Size of disk | `string` | `"gp2"` | no |
-| <a name="input_ingress_cidr_blocks"></a> [ingress\_cidr\_blocks](#input\_ingress\_cidr\_blocks) | Set CIDR to receive traffic from the specified IPv4 CIDR address ranges<br/>	For example x.x.x.x/32 to allow one specific IP address access, 0.0.0.0/0 to allow all IP addresses access, or another CIDR range<br/>    Best practice is to allow a few IPs as possible<br/>    The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X | `list(any)` | n/a | yes |
+| <a name="input_ebs_disk_type"></a> [ebs\_disk\_type](#input\_ebs\_disk\_type) | EBS volume type | `string` | `"gp3"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The instance type of the vSocket | `string` | `"c5.xlarge"` | no |
 | <a name="input_internet_gateway_id"></a> [internet\_gateway\_id](#input\_internet\_gateway\_id) | Specify an Internet Gateway ID to use. If not specified, a new Internet Gateway will be created. | `string` | `null` | no |
 | <a name="input_key_pair"></a> [key\_pair](#input\_key\_pair) | Name of an existing Key Pair for AWS encryption | `string` | n/a | yes |
@@ -239,9 +248,10 @@ No modules.
 | <a name="input_license_id"></a> [license\_id](#input\_license\_id) | The license ID for the Cato vSocket of license type CATO\_SITE, CATO\_SSE\_SITE, CATO\_PB, CATO\_PB\_SSE.  Example License ID value: 'abcde123-abcd-1234-abcd-abcde1234567'.  Note that licenses are for commercial accounts, and not supported for trial accounts. | `string` | `null` | no |
 | <a name="input_mgmt_eni_primary_ip"></a> [mgmt\_eni\_primary\_ip](#input\_mgmt\_eni\_primary\_ip) | Choose an IP Address within the Management Subnet. You CANNOT use the first four assignable IP addresses within the subnet as it's reserved for the AWS virtual router interface. The accepted input format is X.X.X.X | `string` | n/a | yes |
 | <a name="input_mgmt_eni_secondary_ip"></a> [mgmt\_eni\_secondary\_ip](#input\_mgmt\_eni\_secondary\_ip) | Choose an IP Address within the Management Subnet. You CANNOT use the first four assignable IP addresses within the subnet as it's reserved for the AWS virtual router interface. The accepted input format is X.X.X.X | `string` | n/a | yes |
-| <a name="input_native_network_range"></a> [native\_network\_range](#input\_native\_network\_range) | Choose a unique range for your new vsocket site that does not conflict with the rest of your Wide Area Network.<br/>    The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_routed_networks"></a> [routed\_networks](#input\_routed\_networks) | A map of routed networks to be accessed behind the vSocket site. The key is the network name and the value is the CIDR range.<br/>  Example: <br/>  routed\_networks = {<br/>  "Peered-VNET-1" = "10.100.1.0/24"<br/>  "On-Prem-Network" = "192.168.50.0/24"<br/>  "Management-Subnet" = "10.100.2.0/25"<br/>  } | `map(string)` | `{}` | no |
 | <a name="input_site_description"></a> [site\_description](#input\_site\_description) | Description of the vsocket site | `string` | n/a | yes |
-| <a name="input_site_location"></a> [site\_location](#input\_site\_location) | The Site Location Data | <pre>object({<br/>    city         = string<br/>    country_code = string<br/>    state_code   = string<br/>    timezone     = string<br/>  })</pre> | n/a | yes |
+| <a name="input_site_location"></a> [site\_location](#input\_site\_location) | Site location which is used by the Cato Socket to connect to the closest Cato PoP. If not specified, the location will be derived from the Azure region dynamicaly. | <pre>object({<br/>    city         = string<br/>    country_code = string<br/>    state_code   = string<br/>    timezone     = string<br/>  })</pre> | <pre>{<br/>  "city": null,<br/>  "country_code": null,<br/>  "state_code": null,<br/>  "timezone": null<br/>}</pre> | no |
 | <a name="input_site_name"></a> [site\_name](#input\_site\_name) | Name of the vsocket site | `string` | n/a | yes |
 | <a name="input_site_type"></a> [site\_type](#input\_site\_type) | The type of the site | `string` | `"CLOUD_DC"` | no |
 | <a name="input_subnet_range_lan_primary"></a> [subnet\_range\_lan\_primary](#input\_subnet\_range\_lan\_primary) | Choose a range within the VPC to use as the Private/LAN subnet. This subnet will host the target LAN interface of the vSocket so resources in the VPC (or AWS Region) can route to the Cato Cloud.<br/>    The minimum subnet length to support High Availability is /29.<br/>    The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X | `string` | n/a | yes |
@@ -285,6 +295,7 @@ No modules.
 | <a name="output_mgmteip_secondary"></a> [mgmteip\_secondary](#output\_mgmteip\_secondary) | Public IP address of the secondary management Elastic IP |
 | <a name="output_sg_external"></a> [sg\_external](#output\_sg\_external) | ID of the external security group that governs Internet‑facing traffic |
 | <a name="output_sg_internal"></a> [sg\_internal](#output\_sg\_internal) | ID of the internal security group that controls traffic for vSockets |
+| <a name="output_site_location"></a> [site\_location](#output\_site\_location) | n/a |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC ID (existing or newly created) hosting the vSocket resources |
 | <a name="output_wan_eni_primary_id"></a> [wan\_eni\_primary\_id](#output\_wan\_eni\_primary\_id) | WAN ENI ID for outbound Internet connectivity on the first vSocket |
 | <a name="output_wan_eni_secondary_id"></a> [wan\_eni\_secondary\_id](#output\_wan\_eni\_secondary\_id) | WAN ENI ID for outbound Internet connectivity on the standby vSocket |

--- a/changelog.md
+++ b/changelog.md
@@ -65,3 +65,19 @@
 
 ### Features
 - Adjusted EBS Disk type from GP2 to GP3 
+
+
+## 0.1.3 (2025-06-27)
+This release focuses on adding new networking features, simplifying configuration, improving stability, and refactoring the codebase for long-term maintenance.
+
+### New Features
+* **Added Support for Routed Networks:** Introduced a new `routed_networks` variable. This allows you to define a map of network names and CIDR ranges that should be routed through the Cato site, which are configured via the new `cato_network_range` resource.
+* **Automatic Site Location:** The `site_location` is now automatically derived from the configured AWS `region`, simplifying site creation. As a result, the `site_location` variable is now optional.
+* **Simplified Native Network Configuration:** To reduce user input, the `native_network_range` variable has been removed. Its value is now automatically inferred from the `subnet_range_lan_primary`.
+### Bug Fixes
+* **Fix Routed Network Creation Order:** Resolved a race condition by adding an explicit `depends_on` block to the new routed network resources. This ensures the Cato site is fully provisioned before attempting to add networks, preventing potential API errors.
+### Housekeeping & Refactoring
+* **Modernize Resource Triggers:** Replaced the legacy `null_resource` with the modern `terraform_data` resource for configuring the secondary vSocket. The `local-exec` provisioner was also refactored to use a separate `templatefile` for the API payload, significantly improving code readability and maintenance.
+* **Code Cleanup:** Removed several unused variables (`ingress_cidr_blocks`), data sources (`aws_ami`, `aws_availability_zones`), and `locals` as identified by `tflint`.
+* **Updated Default EBS Volume Type:** The default `ebs_disk_type` for the vSocket instances has been changed from `gp2` to the more modern and cost-effective `gp3`.
+* **Updated Dependency Versions:** Raised the minimum required versions for Terraform (`>= 1.5`), the AWS provider (`>= 5.98.0`), and the Cato provider (`>= 0.0.27`) to ensure compatibility with new features and best practices.

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,25 @@
+# Retrieve Secondary vSocket Virtual Machine serial
+data "cato_accountSnapshotSite" "aws-site-secondary" {
+  depends_on = [null_resource.sleep_30_seconds]
+  id         = cato_socket_site.aws-site.id
+}
+
+data "cato_accountSnapshotSite" "aws-site-2" {
+  id         = cato_socket_site.aws-site.id
+  depends_on = [null_resource.sleep_300_seconds-HA]
+}
+
+data "cato_accountSnapshotSite" "aws-site-primary" {
+  id = cato_socket_site.aws-site.id
+}
+
+## Lookup data from region and VPC
+data "aws_ami" "vsocket" {
+  most_recent = true
+  name_regex  = "VSOCKET_AWS"
+  owners      = ["aws-marketplace"]
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  primary_serial = [for s in data.cato_accountSnapshotSite.aws-site-primary.info.sockets : s.serial if s.is_primary == true]
+  sanitized_name = replace(replace(replace(replace(replace(replace(
+    var.site_name,
+    "/", ""),
+    ":", ""),
+    "#", ""),
+    "(", ""),
+    ")", ""),
+  " ", "-")
+
+  secondary_serial = [for s in data.cato_accountSnapshotSite.aws-site-secondary.info.sockets : s.serial if s.is_primary == false]
+}

--- a/main.tf
+++ b/main.tf
@@ -17,11 +17,6 @@ resource "aws_internet_gateway" "internet_gateway" {
   vpc_id = var.vpc_id == null ? aws_vpc.cato-vpc[0].id : var.vpc_id
 }
 
-# Lookup data from region and VPC - Always needed for availability zones
-data "aws_availability_zones" "available_zones" {
-  state = "available"
-}
-
 # Subnets
 resource "aws_subnet" "mgmt_subnet_primary" {
   vpc_id            = var.vpc_id == null ? aws_vpc.cato-vpc[0].id : var.vpc_id
@@ -343,27 +338,21 @@ resource "cato_socket_site" "aws-site" {
   description     = var.site_description
   name            = var.site_name
   native_range = {
-    native_network_range = var.native_network_range
+    native_network_range = var.subnet_range_lan_primary #Native_network_Range is inferred by the Socket Lan Subnet Primary
     local_ip             = var.lan_eni_primary_ip
   }
-  site_location = var.site_location
+  site_location = local.cur_site_location
   site_type     = var.site_type
 }
 
-data "cato_accountSnapshotSite" "aws-site-primary" {
-  id = cato_socket_site.aws-site.id
-}
 
-locals {
-  primary_serial = [for s in data.cato_accountSnapshotSite.aws-site-primary.info.sockets : s.serial if s.is_primary == true]
-  sanitized_name = replace(replace(replace(replace(replace(replace(
-    var.site_name,
-    "/", ""),
-    ":", ""),
-    "#", ""),
-    "(", ""),
-    ")", ""),
-  " ", "-")
+resource "cato_network_range" "routedNetworks" {
+  for_each   = var.routed_networks
+  site_id    = cato_socket_site.aws-site.id
+  name       = each.key # The name is the key from the map item.
+  range_type = "Routed"
+  subnet     = each.value # The subnet is the value from the map item.
+  depends_on = [data.cato_accountSnapshotSite.aws-site-2]
 }
 
 # AWS HA IAM role configuration
@@ -419,17 +408,6 @@ resource "aws_iam_instance_profile" "cato_ha_instance_profile" {
   })
 }
 
-## Lookup data from region and VPC
-data "aws_ami" "vsocket" {
-  most_recent = true
-  name_regex  = "VSOCKET_AWS"
-  owners      = ["aws-marketplace"]
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
 # Create Primary vSocket Virtual Machine
 resource "aws_instance" "primary_vsocket" {
   tenancy              = "default"
@@ -472,41 +450,34 @@ resource "null_resource" "sleep_300_seconds" {
   depends_on = [aws_instance.primary_vsocket]
 }
 
-#################################################################################
-# Add secondary socket to site via API until socket_site resource is updated to natively support
-resource "null_resource" "configure_secondary_aws_vsocket" {
+resource "terraform_data" "configure_secondary_aws_vsocket" {
   depends_on = [null_resource.sleep_300_seconds]
 
-  provisioner "local-exec" {
-    command = <<EOF
-      # Execute the GraphQL mutation to get add the secondary vSocket
-      response=$(curl -k -X POST \
-        -H "Accept: application/json" \
-        -H "Content-Type: application/json" \
-        -H "x-API-Key: ${var.token}" \
-        "${var.baseurl}" \
-        --data '{
-          "query": "mutation siteAddSecondaryAwsVSocket($accountId: ID!, $addSecondaryAwsVSocketInput: AddSecondaryAwsVSocketInput!) { site(accountId: $accountId) { addSecondaryAwsVSocket(input: $addSecondaryAwsVSocketInput) { id } } }",
-          "variables": {
-            "accountId": "${var.account_id}",
-            "addSecondaryAwsVSocketInput": {
-              "eniIpAddress": "${var.lan_eni_secondary_ip}",
-              "eniIpSubnet": "${var.subnet_range_lan_secondary}",
-               "routeTableId": "${aws_route_table.lanrt.id}",
-              "site": {
-                "by": "ID",
-                "input": "${cato_socket_site.aws-site.id}"
-              }
-            }
-          },
-          "operationName": "siteAddSecondaryAwsVSocket"
-        }' )
-    EOF
+  # The `input` block serves as the trigger for this resource.
+  # If any of these values change, Terraform will replace the resource,
+  # causing the provisioner to run again. This is the modern replacement
+  # for the `triggers` argument in null_resource.
+  input = {
+    account_id     = var.account_id
+    site_id        = cato_socket_site.aws-site.id
+    eni_ip_address = var.lan_eni_secondary_ip
+    eni_ip_subnet  = var.subnet_range_lan_secondary
+    route_table_id = aws_route_table.lanrt.id
   }
 
-  triggers = {
-    account_id = var.account_id
-    site_id    = cato_socket_site.aws-site.id
+  provisioner "local-exec" {
+    # The command is now cleaner. It calls the curl command and uses the
+    # templatefile() function to dynamically generate the JSON payload from
+    # an external template file. This avoids the large, hard-to-read heredoc.
+    command = templatefile("${path.module}/templates/secondary_socket_payload.json.tftpl", {
+      account_id     = self.input.account_id,
+      site_id        = self.input.site_id,
+      eni_ip_address = self.input.eni_ip_address,
+      eni_ip_subnet  = self.input.eni_ip_subnet,
+      route_table_id = self.input.route_table_id
+      api_token      = var.token
+      baseurl        = var.baseurl
+    })
   }
 }
 
@@ -515,18 +486,7 @@ resource "null_resource" "sleep_30_seconds" {
   provisioner "local-exec" {
     command = "sleep 30"
   }
-  depends_on = [null_resource.configure_secondary_aws_vsocket]
-}
-
-# Retrieve Secondary vSocket Virtual Machine serial
-data "cato_accountSnapshotSite" "aws-site-secondary" {
-  depends_on = [null_resource.sleep_30_seconds]
-  id         = cato_socket_site.aws-site.id
-}
-
-locals {
-  secondary_serial = [for s in data.cato_accountSnapshotSite.aws-site-secondary.info.sockets : s.serial if s.is_primary == false]
-  depends_on       = [data.cato_accountSnapshotSite.aws-site-secondary]
+  depends_on = [terraform_data.configure_secondary_aws_vsocket]
 }
 
 ## vSocket Instance
@@ -570,11 +530,6 @@ resource "null_resource" "sleep_300_seconds-HA" {
     command = "sleep 300"
   }
   depends_on = [aws_instance.secondary_vsocket]
-}
-
-data "cato_accountSnapshotSite" "aws-site-2" {
-  id         = cato_socket_site.aws-site.id
-  depends_on = [null_resource.sleep_300_seconds-HA]
 }
 
 resource "cato_license" "license" {

--- a/main.tf
+++ b/main.tf
@@ -414,7 +414,7 @@ resource "aws_instance" "primary_vsocket" {
   ami                  = data.aws_ami.vsocket.id
   key_name             = var.key_pair
   instance_type        = var.instance_type
-  user_data            = base64encode(local.primary_serial[0])
+  user_data_base64     = base64encode(local.primary_serial[0])
   iam_instance_profile = aws_iam_instance_profile.cato_ha_instance_profile.name
   # Network Interfaces
   # MGMTENI
@@ -495,7 +495,7 @@ resource "aws_instance" "secondary_vsocket" {
   ami                  = data.aws_ami.vsocket.id
   key_name             = var.key_pair
   instance_type        = var.instance_type
-  user_data            = base64encode(local.secondary_serial[0])
+  user_data_base64     = base64encode(local.secondary_serial[0])
   iam_instance_profile = aws_iam_instance_profile.cato_ha_instance_profile.name
   # Network Interfaces
   # MGMTENI

--- a/site_location_aws.tf
+++ b/site_location_aws.tf
@@ -1,0 +1,108 @@
+
+# Only run this data block if var.site_location is null
+# (Terraform does not support dynamic data blocks, so we use count)
+data "cato_siteLocation" "site_location" {
+  count = local.all_location_fields_null ? 1 : 0
+  filters = concat([
+    {
+      field     = "city"
+      operation = "exact"
+      search    = local.region_to_location[local.locationstr].city
+    },
+    {
+      field     = "country_name"
+      operation = "exact"
+      search    = local.region_to_location[local.locationstr].country
+    }
+    ],
+    local.region_to_location[local.locationstr].state != null ? [
+      {
+        field     = "state_name"
+        operation = "exact"
+        search    = local.region_to_location[local.locationstr].state
+      }
+  ] : [])
+}
+
+locals {
+  ## Check for all site_location inputs to be null
+  all_location_fields_null = (
+    var.site_location.city == null &&
+    var.site_location.country_code == null &&
+    var.site_location.state_code == null &&
+    var.site_location.timezone == null
+  ) ? true : false
+
+  ## If all site_location fields are null, use the data source to fetch the 
+  ## site_location from azure provuder location, else use var.site_location
+  cur_site_location = local.all_location_fields_null ? {
+    country_code = data.cato_siteLocation.site_location[0].locations[0].country_code
+    timezone     = data.cato_siteLocation.site_location[0].locations[0].timezone[0]
+    state_code   = data.cato_siteLocation.site_location[0].locations[0].state_code
+    city         = data.cato_siteLocation.site_location[0].locations[0].city
+  } : var.site_location
+
+  locationstr = lower(replace(var.region, " ", ""))
+  # Manual mapping of Azure regions to their cities and countries
+  # Since Azure doesn't provide city/country in the API, we create our own mapping
+  region_to_location = {
+    # North America - United States
+    "us-east-1"     = { city = "Ashburn", state = "Virginia", country = "United States", timezone = "UTC-5" }
+    "us-east-2"     = { city = "Columbus", state = "Ohio", country = "United States", timezone = "UTC-5" }
+    "us-west-1"     = { city = "San Francisco", state = "California", country = "United States", timezone = "UTC-8" }
+    "us-west-2"     = { city = "Boardman", state = "Oregon", country = "United States", timezone = "UTC-8" }
+    "us-gov-east-1" = { city = "Fairfax", state = "Virginia", country = "United States", timezone = "UTC-5" }
+    "us-gov-west-1" = { city = "Boardman", state = "Oregon", country = "United States", timezone = "UTC-8" }
+
+    # North America - Canada
+    "ca-central-1" = { city = "Montr\u00c3\u00a9al", state = null, country = "Canada", timezone = "UTC-5" }
+    "ca-west-1"    = { city = "Calgary", state = null, country = "Canada", timezone = "UTC-7" }
+
+    # North America - Mexico
+    "mx-central-1" = { city = "Austin", state = "Texas", country = "United States", timezone = "UTC-6" }
+
+    # Europe
+    "eu-central-1" = { city = "Frankfurt (Oder)", state = null, country = "Germany", timezone = "UTC+1" }
+    "eu-central-2" = { city = "Z\u00c3\u00bcrich", state = null, country = "Switzerland", timezone = "UTC+1" }
+    "eu-west-1"    = { city = "Dublin", state = null, country = "Ireland", timezone = "UTC+0" }
+    "eu-west-2"    = { city = "London", state = null, country = "United Kingdom", timezone = "UTC+0" }
+    "eu-west-3"    = { city = "Paris", state = null, country = "France", timezone = "UTC+1" }
+    "eu-north-1"   = { city = "Stockholm", state = null, country = "Sweden", timezone = "UTC+1" }
+    "eu-south-1"   = { city = "Milan", state = null, country = "Italy", timezone = "UTC+1" }
+    "eu-south-2"   = { city = "Madrid", state = null, country = "Spain", timezone = "UTC+1" }
+
+    # Asia Pacific
+    "ap-east-1"      = { city = "Hong Kong", state = null, country = "Hong Kong", timezone = "UTC+8" }
+    "ap-east-2"      = { city = "Taipei", state = null, country = "Taiwan", timezone = "UTC+8" }
+    "ap-south-1"     = { city = "Mumbai", state = "Maharashtra", country = "India", timezone = "UTC+5:30" }
+    "ap-south-2"     = { city = "Chennai", state = "Tamil Nadu", country = "India", timezone = "UTC+5:30" }
+    "ap-northeast-1" = { city = "Tokyo", state = null, country = "Japan", timezone = "UTC+9" }
+    "ap-northeast-2" = { city = "Seoul", state = null, country = "South Korea", timezone = "UTC+9" }
+    "ap-northeast-3" = { city = "Osaka", state = null, country = "Japan", timezone = "UTC+9" }
+    "ap-southeast-1" = { city = "Singapore", state = null, country = "Singapore", timezone = "UTC+8" }
+    "ap-southeast-2" = { city = "Sydney", state = "New South Wales", country = "Australia", timezone = "UTC+10" }
+    "ap-southeast-3" = { city = "Jakarta", state = null, country = "Indonesia", timezone = "UTC+7" }
+    "ap-southeast-4" = { city = "Melbourne", state = "Victoria", country = "Australia", timezone = "UTC+10" }
+    "ap-southeast-5" = { city = "Kuala Lumpur", state = null, country = "Malaysia", timezone = "UTC+8" }
+    "ap-southeast-7" = { city = "Bangkok", state = null, country = "Thailand", timezone = "UTC+7" }
+
+    # Middle East
+    "me-south-1"   = { city = "Manama", state = null, country = "Bahrain", timezone = "UTC+3" }
+    "me-central-1" = { city = "Dubai", state = null, country = "United Arab Emirates", timezone = "UTC+4" }
+    "il-central-1" = { city = "Tel Aviv", state = null, country = "Israel", timezone = "UTC+2" }
+
+    # Africa
+    "af-south-1" = { city = "Cape Town", state = null, country = "South Africa", timezone = "UTC+2" }
+
+    # South America
+    "sa-east-1" = { city = "S\u00c3\u00a3o Paulo", state = "S\u00c3\u00a3o Paulo", country = "Brazil", timezone = "UTC-3" }
+
+    # China (Isolated regions)
+    "cn-north-1"     = { city = "Beijing", state = null, country = "China", timezone = "UTC+8" }
+    "cn-northwest-1" = { city = "Beijing", state = null, country = "China", timezone = "UTC+8" }
+  }
+}
+
+output "site_location" {
+  value = data.cato_siteLocation.site_location
+}

--- a/templates/secondary_socket_payload.json.tftpl
+++ b/templates/secondary_socket_payload.json.tftpl
@@ -1,0 +1,21 @@
+response=$(curl -v -k -X POST \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -H "x-API-Key: ${api_token}" \
+  "${baseurl}" \
+  --data '{
+    "query": "mutation siteAddSecondaryAwsVSocket($accountId: ID!, $addSecondaryAwsVSocketInput: AddSecondaryAwsVSocketInput!) { site(accountId: $accountId) { addSecondaryAwsVSocket(input: $addSecondaryAwsVSocketInput) { id } } }",
+    "variables": {
+      "accountId": "${account_id}",
+      "addSecondaryAwsVSocketInput": {
+        "eniIpAddress": "${eni_ip_address}",
+        "eniIpSubnet": "${eni_ip_subnet}",
+        "routeTableId": "${route_table_id}",
+        "site": {
+          "by": "ID",
+          "input": "${site_id}"
+        }
+      }
+    },
+"operationName": "siteAddSecondaryAwsVSocket"
+}' )

--- a/templates/secondary_socket_payload.json.tftpl
+++ b/templates/secondary_socket_payload.json.tftpl
@@ -1,4 +1,4 @@
-response=$(curl -v -k -X POST \
+response=$(curl -k -X POST \
   -H "Accept: application/json" \
   -H "Content-Type: application/json" \
   -H "x-API-Key: ${api_token}" \

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,7 @@ variable "baseurl" {
 variable "token" {
   description = "Cato API token"
   type        = string
+  #sensitive   = true
 }
 
 variable "account_id" {
@@ -28,14 +29,6 @@ variable "vpc_range" {
     The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X
 	EOT
   default     = null
-}
-
-variable "native_network_range" {
-  type        = string
-  description = <<EOT
-  	Choose a unique range for your new vsocket site that does not conflict with the rest of your Wide Area Network.
-    The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X
-	EOT
 }
 
 variable "internet_gateway_id" {
@@ -70,32 +63,22 @@ variable "site_type" {
 }
 
 variable "site_location" {
-  description = "The Site Location Data"
+  description = "Site location which is used by the Cato Socket to connect to the closest Cato PoP. If not specified, the location will be derived from the Azure region dynamicaly."
   type = object({
     city         = string
     country_code = string
     state_code   = string
     timezone     = string
   })
-  # default = {
-  #   city         = "New York"
-  #   country_code = "US"
-  #   state_code   = "US-NY" ## Optional - for coutnries with states
-  #   timezone     = "America/New_York"
-  # }
+  default = {
+    city         = null
+    country_code = null
+    state_code   = null ## Optional - for countries with states
+    timezone     = null
+  }
 }
 
 ## VPC Module Variables
-variable "ingress_cidr_blocks" {
-  type        = list(any)
-  description = <<EOT
-  	Set CIDR to receive traffic from the specified IPv4 CIDR address ranges
-	For example x.x.x.x/32 to allow one specific IP address access, 0.0.0.0/0 to allow all IP addresses access, or another CIDR range
-    Best practice is to allow a few IPs as possible
-    The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X
-	EOT  
-}
-
 variable "lan_ingress_cidr_blocks" {
   type        = list(any)
   description = <<EOT
@@ -232,4 +215,23 @@ variable "license_bw" {
   description = "The license bandwidth number for the cato site, specifying bandwidth ONLY applies for pooled licenses.  For a standard site license that is not pooled, leave this value null. Must be a number greater than 0 and an increment of 10."
   type        = string
   default     = null
+}
+
+variable "routed_networks" {
+  description = <<EOF
+  A map of routed networks to be accessed behind the vSocket site. The key is the network name and the value is the CIDR range.
+  Example: 
+  routed_networks = {
+  "Peered-VNET-1" = "10.100.1.0/24"
+  "On-Prem-Network" = "192.168.50.0/24"
+  "Management-Subnet" = "10.100.2.0/25"
+  }
+  EOF
+  type        = map(string)
+  default     = {} # Default to an empty map instead of null.
+}
+
+variable "region" {
+  description = "AWS Region"
+  type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "baseurl" {
 variable "token" {
   description = "Cato API token"
   type        = string
-  #sensitive   = true
+  sensitive   = true
 }
 
 variable "account_id" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,11 +1,13 @@
 terraform {
   required_providers {
     cato = {
-      source = "catonetworks/cato"
+      source  = "catonetworks/cato"
+      version = ">= 0.0.27"
     }
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 5.98.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.5"
 }


### PR DESCRIPTION
This release focuses on adding new networking features, simplifying configuration, improving stability, and refactoring the codebase for long-term maintenance.

Tested cleanly 3 times after adding 5 minutes between secondary socket and route creation.

## 0.1.3 (2025-06-27)

### New Features
* **Added Support for Routed Networks:** Introduced a new `routed_networks` variable. This allows you to define a map of network names and CIDR ranges that should be routed through the Cato site, which are configured via the new `cato_network_range` resource.
* **Automatic Site Location:** The `site_location` is now automatically derived from the configured AWS `region`, simplifying site creation. As a result, the `site_location` variable is now optional.
* **Simplified Native Network Configuration:** To reduce user input, the `native_network_range` variable has been removed. Its value is now automatically inferred from the `subnet_range_lan_primary`.
### Bug Fixes
* **Fix Routed Network Creation Order:** Resolved a race condition by adding an explicit `depends_on` block to the new routed network resources. This ensures the Cato site is fully provisioned before attempting to add networks, preventing potential API errors.
### Housekeeping & Refactoring
* **Modernize Resource Triggers:** Replaced the legacy `null_resource` with the modern `terraform_data` resource for configuring the secondary vSocket. The `local-exec` provisioner was also refactored to use a separate `templatefile` for the API payload, significantly improving code readability and maintenance.
* **Code Cleanup:** Removed several unused variables (`ingress_cidr_blocks`), data sources (`aws_ami`, `aws_availability_zones`), and `locals` as identified by `tflint`.
* **Updated Default EBS Volume Type:** The default `ebs_disk_type` for the vSocket instances has been changed from `gp2` to the more modern and cost-effective `gp3`.
* **Updated Dependency Versions:** Raised the minimum required versions for Terraform (`>= 1.5`), the AWS provider (`>= 5.98.0`), and the Cato provider (`>= 0.0.27`) to ensure compatibility with new features and best practices.